### PR TITLE
[FLINK-36245][core] remove SinkV1 API and SinkV1Adapter, and replace …

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/WithAdapterCommitterOperatorTest.java
@@ -20,8 +20,7 @@ package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.api.connector.sink2.SupportsCommitter;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Collection;
 
 class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
 
@@ -30,13 +29,11 @@ class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
         ForwardingCommitter committer = new ForwardingCommitter();
         return new SinkAndCounters(
                 (SupportsCommitter<String>)
-                        TestSink.newBuilder()
+                        TestSinkV2.<String>newBuilder()
                                 .setCommitter(committer)
-                                .setDefaultGlobalCommitter()
-                                .setCommittableSerializer(
-                                        TestSink.StringCommittableSerializer.INSTANCE)
-                                .build()
-                                .asV2(),
+                                .setWithPostCommitTopology(true)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .build(),
                 () -> committer.successfulCommits);
     }
 
@@ -44,13 +41,11 @@ class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
     SinkAndCounters sinkWithPostCommitWithRetry() {
         return new SinkAndCounters(
                 (SupportsCommitter<String>)
-                        TestSink.newBuilder()
-                                .setCommitter(new TestSink.RetryOnceCommitter())
-                                .setDefaultGlobalCommitter()
-                                .setCommittableSerializer(
-                                        TestSink.StringCommittableSerializer.INSTANCE)
-                                .build()
-                                .asV2(),
+                        TestSinkV2.<String>newBuilder()
+                                .setCommitter(new TestSinkV2.RetryOnceCommitter())
+                                .setWithPostCommitTopology(true)
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .build(),
                 () -> 0);
     }
 
@@ -59,22 +54,19 @@ class WithAdapterCommitterOperatorTest extends CommitterOperatorTestBase {
         ForwardingCommitter committer = new ForwardingCommitter();
         return new SinkAndCounters(
                 (SupportsCommitter<String>)
-                        TestSink.newBuilder()
+                        TestSinkV2.<String>newBuilder()
                                 .setCommitter(committer)
-                                .setCommittableSerializer(
-                                        TestSink.StringCommittableSerializer.INSTANCE)
-                                .build()
-                                .asV2(),
+                                .setCommittableSerializer(TestSinkV2.StringSerializer.INSTANCE)
+                                .build(),
                 () -> committer.successfulCommits);
     }
 
-    private static class ForwardingCommitter extends TestSink.DefaultCommitter {
+    private static class ForwardingCommitter extends TestSinkV2.DefaultCommitter {
         private int successfulCommits = 0;
 
         @Override
-        public List<String> commit(List<String> committables) {
+        public void commit(Collection<CommitRequest<String>> committables) {
             successfulCommits += committables.size();
-            return Collections.emptyList();
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
@@ -19,7 +19,7 @@ package org.apache.flink.test.streaming.runtime;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.connector.sink.Sink;
+import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.metrics.Metric;
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.testutils.InMemoryReporter;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.SharedObjects;
 import org.apache.flink.testutils.junit.SharedReference;
@@ -101,11 +101,7 @@ public class SinkMetricsITCase extends TestLogger {
                             }
                             return i;
                         })
-                .sinkTo(
-                        TestSink.newBuilder()
-                                .setDefaultCommitter()
-                                .setWriter(new MetricWriter())
-                                .build())
+                .sinkTo(TestSinkV2.<Long>newBuilder().setWriter(new MetricWriter()).build())
                 .name(TEST_SINK_NAME);
         JobClient jobClient = env.executeAsync();
         final JobID jobId = jobClient.getJobID();
@@ -182,7 +178,7 @@ public class SinkMetricsITCase extends TestLogger {
         assertThat(subtaskWithTaskMetrics, equalTo(numSplits));
     }
 
-    private static class MetricWriter extends TestSink.DefaultSinkWriter<Long> {
+    private static class MetricWriter extends TestSinkV2.DefaultSinkWriter<Long> {
         static final long BASE_SEND_TIME = 100;
         static final long RECORD_SIZE_IN_BYTES = 10;
         private SinkWriterMetricGroup metricGroup;


### PR DESCRIPTION
…all usage in test to SinkV2 API.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
