### PR TITLE
internal.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.sink;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.io.CleanupWhenUnsuccessful;
@@ -41,7 +40,6 @@ import java.io.IOException;
  *     org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink StreamingFileSink}
  *     for writing to files from a streaming program.
  */
-@PublicEvolving
 @Deprecated
 public class OutputFormatSinkFunction<IN> extends RichSinkFunction<IN>
         implements InputTypeConfigurable {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSinkFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/PrintSinkFunction.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.sink;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
 import org.apache.flink.api.common.functions.util.PrintSinkOutputWriter;
 import org.apache.flink.configuration.Configuration;
@@ -37,7 +36,6 @@ import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
  *     interface instead.
  */
 @Deprecated
-@PublicEvolving
 public class PrintSinkFunction<IN> extends RichSinkFunction<IN>
         implements SupportsConcurrentExecutionAttempts {
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/SinkFunction.java
@@ -31,7 +31,6 @@ import java.io.Serializable;
  *     org.apache.flink.api.connector.sink2.Sink} interface instead.
  */
 @Deprecated
-@Public
 public interface SinkFunction<IN> extends Function, Serializable {
 
     /** @deprecated Use {@link #invoke(Object, Context)}. */

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.sink;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.SerializableObject;
@@ -46,7 +45,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     org.apache.flink.api.connector.sink2.Sink} interface instead.
  */
 @Deprecated
-@PublicEvolving
 public class SocketClientSink<IN> extends RichSinkFunction<IN> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.source;
 
-import org.apache.flink.annotation.PublicEvolving;
-
 import java.util.Iterator;
 
 /**
@@ -29,7 +27,6 @@ import java.util.Iterator;
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Deprecated
-@PublicEvolving
 public class FromIteratorFunction<T> implements SourceFunction<T> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/FromSplittableIteratorFunction.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.source;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.SplittableIterator;
 
@@ -31,7 +30,6 @@ import java.util.Iterator;
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Deprecated
-@PublicEvolving
 public class FromSplittableIteratorFunction<T> extends RichParallelSourceFunction<T> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.api.functions.source;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.util.IOUtils;
 
 import org.slf4j.Logger;
@@ -48,7 +47,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
 @Deprecated
-@PublicEvolving
 public class SocketTextStreamFunction implements SourceFunction<String> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -99,7 +99,6 @@ import java.io.Serializable;
  *     FLINK-28045 must be closed before this API can be completely removed.
  */
 @Deprecated
-@Public
 public interface SourceFunction<T> extends Function, Serializable {
 
     /**

--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/sink/AlertSink.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/sink/AlertSink.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.walkthrough.common.sink;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.walkthrough.common.entity.Alert;
 
@@ -26,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A sink for outputting alerts. */
-@PublicEvolving
+@Deprecated
 @SuppressWarnings("unused")
 public class AlertSink implements SinkFunction<Alert> {
 

--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/source/TransactionSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.walkthrough.common.source;
 
-import org.apache.flink.annotation.Public;
 import org.apache.flink.streaming.api.functions.source.FromIteratorFunction;
 import org.apache.flink.walkthrough.common.entity.Transaction;
 
@@ -32,7 +31,7 @@ import java.util.Iterator;
  *     org.apache.flink.streaming.api.functions.source.SourceFunction} API, which is due to be
  *     removed. Use the new {@link org.apache.flink.api.connector.source.Source} API instead.
  */
-@Public
+@Deprecated
 public class TransactionSource extends FromIteratorFunction<Transaction> {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
