### PR TITLE
[FLINK-38497][connector] FLIP-535:Introduce RateLimiter to Source.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
 import javax.annotation.Nullable;
 
@@ -83,10 +82,9 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
     }
 
     /**
-     * The primary constructor for the source reader.
-     *
-     * <p>The reader will use a handover queue sized as configured via {@link
-     * SourceReaderOptions#ELEMENT_QUEUE_CAPACITY}.
+     * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
+     * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
+     * RateLimiterStrategy}.
      */
     public SingleThreadMultiplexSourceReaderBase(
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
@@ -106,7 +104,7 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
     /**
      * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
-     * FutureCompletingBlockingQueue} and {@link SingleThreadFetcherManager}.
+     * SingleThreadFetcherManager}.
      */
     public SingleThreadMultiplexSourceReaderBase(
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
@@ -119,8 +117,7 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
     /**
      * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
-     * FutureCompletingBlockingQueue}, {@link SingleThreadFetcherManager} and {@link
-     * RecordEvaluator}.
+     * SingleThreadFetcherManager} and {@link RecordEvaluator}.
      */
     public SingleThreadMultiplexSourceReaderBase(
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
@@ -132,10 +129,10 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
     }
 
     /**
-     * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
-     * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
-     * FutureCompletingBlockingQueue}, {@link SingleThreadFetcherManager}, {@link RecordEvaluator}
-     * and {@link RateLimiterStrategy}.
+     * This constructor behaves like {@link
+     * #SingleThreadMultiplexSourceReaderBase(SingleThreadFetcherManager, RecordEmitter,
+     * RecordEvaluator, Configuration, SourceReaderContext)}, but accepts a specific {@link
+     * RateLimiterStrategy}.
      */
     public SingleThreadMultiplexSourceReaderBase(
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -463,7 +463,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
         SourceOutput<T> getOrCreateSplitOutput(
                 ReaderOutput<T> mainOutput,
                 @Nullable Function<T, Boolean> eofRecordHandler,
-                boolean isRateLimited) {
+                boolean rateLimitingEnabled) {
             if (sourceOutput == null) {
                 // The split output should have been created when AddSplitsEvent was processed in
                 // SourceOperator. Here we just use this method to get the previously created
@@ -472,7 +472,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
                 if (eofRecordHandler != null) {
                     sourceOutput = new SourceOutputWrapper<>(sourceOutput, eofRecordHandler);
                 }
-                if (isRateLimited) {
+                if (rateLimitingEnabled) {
                     sourceOutput = new RateLimitingSourceOutputWrapper<>(sourceOutput);
                 }
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -303,14 +303,18 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
     @Override
     public List<SplitT> snapshotState(long checkpointId) {
         List<SplitT> splits = new ArrayList<>();
+        splitStates.forEach((id, context) -> splits.add(toSplitType(id, context.state)));
+        return splits;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
         splitStates.forEach(
                 (id, context) -> {
-                    splits.add(toSplitType(id, context.state));
                     if (rateLimiter != null) {
                         rateLimiter.notifyCheckpointComplete(checkpointId);
                     }
                 });
-        return splits;
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -290,7 +290,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
                     };
         }
         if (isRateLimited) {
-            rateLimiter.notifyStatusChange(
+            rateLimiter.notifyAddingSplit(
                     this.toSplitType(
                             this.currentSplitContext.splitId, this.currentSplitContext.state));
         }
@@ -516,7 +516,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
         final SourceOutput<T> sourceOutput;
 
         /** Count of records handled during the current rate-limiting window. */
-        int currentWindowRecordCount;
+        private int currentWindowRecordCount;
 
         /**
          * Creates a new RecordCountingSourceOutputWrapper.

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -164,6 +164,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
                 isRateLimited
                         ? rateLimiterStrategy.createRateLimiter(context.currentParallelism())
                         : null;
+        rateLimitPermissionFuture = CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -171,8 +171,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         }
         // The first few seconds require preheating, there may be a deviation of a few seconds.
         assertThat(System.currentTimeMillis() - startTime)
-                .isGreaterThan(Duration.ofSeconds(25).toMillis());
-        assertThat(System.currentTimeMillis() - startTime)
+                .isGreaterThan(Duration.ofSeconds(25).toMillis())
                 .isLessThan(Duration.ofSeconds(35).toMillis());
     }
 
@@ -197,8 +196,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
                 reader.pollNext(testingReaderOutput);
             }
             assertThat(testingReaderOutput.getEmittedRecords().size())
-                    .isGreaterThanOrEqualTo(1 + recordsPerCheckpoint * (i - 1));
-            assertThat(testingReaderOutput.getEmittedRecords().size())
+                    .isGreaterThanOrEqualTo(1 + recordsPerCheckpoint * (i - 1))
                     .isLessThanOrEqualTo(1 + recordsPerCheckpoint * i);
             reader.notifyCheckpointComplete(i);
         }
@@ -215,6 +213,8 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         final TestingRecordsWithSplitIds<String> secondRecords =
                 new TestingRecordsWithSplitIds<>("test-split2", recordArr);
         int maxPerSecond = 2;
+        // SplitAwaredRateLimiter will reduce the maxPerSecond for splits whose splitId is not
+        // "test-split1".
         final SourceReader<?, ?> reader =
                 createReaderAndAwaitAvailable(
                         Arrays.asList("test-split1", "test-split2"),
@@ -226,11 +226,10 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         while (testingReaderOutput.getEmittedRecords().size() < 2 * recordArr.length) {
             reader.pollNext(testingReaderOutput);
         }
+        // Expected time: 60/2 ("test-split1") + 60/1 ("test-split2") = 90 seconds.
         // The first few seconds require preheating, there may be a deviation of a few seconds.
         assertThat(System.currentTimeMillis() - startTime)
-                .isGreaterThan(Duration.ofSeconds(85).toMillis());
-        // The first few seconds require preheating, there may be a deviation of a few seconds.
-        assertThat(System.currentTimeMillis() - startTime)
+                .isGreaterThan(Duration.ofSeconds(85).toMillis())
                 .isLessThan(Duration.ofSeconds(95).toMillis());
     }
 
@@ -250,8 +249,8 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         }
 
         @Override
-        public CompletionStage<Void> acquire(int requestSize) {
-            return CompletableFuture.runAsync(() -> rateLimiter.acquire(requestSize), limiter);
+        public CompletionStage<Void> acquire(int numberOfEvents) {
+            return CompletableFuture.runAsync(() -> rateLimiter.acquire(numberOfEvents), limiter);
         }
 
         @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
@@ -130,10 +131,11 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     }
 
     @Test
-    void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
+    void testLimitingRateInSplitReader() throws Exception {
         final TestingRecordsWithSplitIds<String> records =
                 new TestingRecordsWithSplitIds<>("test-split", "value1", "value2");
-        final SourceReader<?, ?> reader = createReaderAndAwaitAvailable("test-split", records);
+        final SourceReader<?, ?> reader =
+                createReaderAndAwaitAvailable("test-split", records, RateLimiterStrategy.noOp());
 
         reader.pollNext(new TestingReaderOutput<>());
 
@@ -141,10 +143,130 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     }
 
     @Test
+    void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
+
+        final TestingRecordsWithSplitIds<String> records =
+                new TestingRecordsWithSplitIds<>(
+                        "test-split",
+                        "value1",
+                        "value2",
+                        "value3",
+                        "value4",
+                        "value5",
+                        "value6",
+                        "value7",
+                        "value8",
+                        "value9",
+                        "value10",
+                        "value11",
+                        "value12",
+                        "value13",
+                        "value14",
+                        "value15",
+                        "value16",
+                        "value17",
+                        "value18",
+                        "value19",
+                        "value20",
+                        "value21",
+                        "value22",
+                        "value23",
+                        "value24",
+                        "value25",
+                        "value26",
+                        "value27",
+                        "value28",
+                        "value29",
+                        "value30",
+                        "value31",
+                        "value32",
+                        "value33",
+                        "value34",
+                        "value35",
+                        "value36",
+                        "value37",
+                        "value38",
+                        "value39",
+                        "value40",
+                        "value41",
+                        "value42",
+                        "value43",
+                        "value44",
+                        "value45",
+                        "value46",
+                        "value47",
+                        "value48",
+                        "value49",
+                        "value50",
+                        "value51",
+                        "value52",
+                        "value53",
+                        "value54",
+                        "value55",
+                        "value56",
+                        "value57",
+                        "value58",
+                        "value59",
+                        "value60",
+                        "value61",
+                        "value62",
+                        "value63",
+                        "value64",
+                        "value65",
+                        "value66",
+                        "value67",
+                        "value68",
+                        "value69",
+                        "value70",
+                        "value71",
+                        "value72",
+                        "value73",
+                        "value74",
+                        "value75",
+                        "value76",
+                        "value77",
+                        "value78",
+                        "value79",
+                        "value80",
+                        "value81",
+                        "value82",
+                        "value83",
+                        "value84",
+                        "value85",
+                        "value86",
+                        "value87",
+                        "value88",
+                        "value89",
+                        "value90",
+                        "value91",
+                        "value92",
+                        "value93",
+                        "value94",
+                        "value95",
+                        "value96",
+                        "value97",
+                        "value98",
+                        "value99",
+                        "value100");
+        final SourceReader<?, ?> reader =
+                createReaderAndAwaitAvailable(
+                        "test-split", records, RateLimiterStrategy.perSecond(1));
+        TestingReaderOutput testingReaderOutput = new TestingReaderOutput<>();
+        long startTime = System.currentTimeMillis();
+        while (testingReaderOutput.getEmittedRecords().size() < 100) {
+            reader.pollNext(testingReaderOutput);
+        }
+        // The first few seconds require preheating, there may be a deviation of a few seconds.
+        assertThat(System.currentTimeMillis() - startTime)
+                .isGreaterThanOrEqualTo(Duration.ofSeconds(90).toMillis());
+    }
+
+    @Test
     void testRecordsWithSplitsRecycledWhenEmpty() throws Exception {
         final TestingRecordsWithSplitIds<String> records =
                 new TestingRecordsWithSplitIds<>("test-split", "value1", "value2");
-        final SourceReader<?, ?> reader = createReaderAndAwaitAvailable("test-split", records);
+        final SourceReader<?, ?> reader =
+                createReaderAndAwaitAvailable("test-split", records, RateLimiterStrategy.noOp());
 
         // poll thrice: twice to get all records, one more to trigger recycle and moving to the next
         // split
@@ -414,7 +536,10 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     // ------------------------------------------------------------------------
 
     private static <E> SourceReader<E, ?> createReaderAndAwaitAvailable(
-            final String splitId, final RecordsWithSplitIds<E> records) throws Exception {
+            final String splitId,
+            final RecordsWithSplitIds<E> records,
+            RateLimiterStrategy<TestingSourceSplit> rateLimiterStrategy)
+            throws Exception {
 
         final SourceReader<E, TestingSourceSplit> reader =
                 new SingleThreadMultiplexSourceReaderBase<
@@ -422,7 +547,8 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
                         () -> new TestingSplitReader<>(records),
                         new PassThroughRecordEmitter<>(),
                         new Configuration(),
-                        new TestingReaderContext()) {
+                        new TestingReaderContext(),
+                        rateLimiterStrategy) {
 
                     @Override
                     public void notifyCheckpointComplete(long checkpointId) {}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -205,7 +205,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     }
 
     @Test
-    void testLimitingRateWithStatusChangeInSplitReader() throws Exception {
+    void testLimitingRateWithAddingSplitInSplitReader() throws Exception {
         String[] recordArr = new String[60];
         for (int i = 0; i < recordArr.length; i++) {
             recordArr[i] = "value" + i;
@@ -237,7 +237,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     /** A rate limiter that reduce the maxPerSecond for specific splits. */
     private static class SplitAwaredRateLimiter
             implements org.apache.flink.api.connector.source.util.ratelimit.RateLimiter<
-                    org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit> {
+                    TestingSourceSplit> {
 
         private final Executor limiter =
                 Executors.newSingleThreadExecutor(new ExecutorThreadFactory("flink-rate-limiter"));
@@ -255,8 +255,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         }
 
         @Override
-        public void notifyStatusChange(
-                org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit split) {
+        public void notifyAddingSplit(TestingSourceSplit split) {
             if (!split.splitId().equals("test-split1")) {
                 this.rateLimiter = RateLimiter.create(maxPerSecond / 2);
             }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -131,7 +131,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     }
 
     @Test
-    void testLimitingRateInSplitReader() throws Exception {
+    void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
         final TestingRecordsWithSplitIds<String> records =
                 new TestingRecordsWithSplitIds<>("test-split", "value1", "value2");
         final SourceReader<?, ?> reader =
@@ -143,122 +143,49 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
     }
 
     @Test
-    void testRecordsWithSplitsNotRecycledWhenRecordsLeft() throws Exception {
-
+    void testLimitingRateInSplitReader() throws Exception {
+        String[] recordArr = new String[100];
+        for (int i = 0; i < recordArr.length; i++) {
+            recordArr[i] = "value" + i;
+        }
         final TestingRecordsWithSplitIds<String> records =
-                new TestingRecordsWithSplitIds<>(
-                        "test-split",
-                        "value1",
-                        "value2",
-                        "value3",
-                        "value4",
-                        "value5",
-                        "value6",
-                        "value7",
-                        "value8",
-                        "value9",
-                        "value10",
-                        "value11",
-                        "value12",
-                        "value13",
-                        "value14",
-                        "value15",
-                        "value16",
-                        "value17",
-                        "value18",
-                        "value19",
-                        "value20",
-                        "value21",
-                        "value22",
-                        "value23",
-                        "value24",
-                        "value25",
-                        "value26",
-                        "value27",
-                        "value28",
-                        "value29",
-                        "value30",
-                        "value31",
-                        "value32",
-                        "value33",
-                        "value34",
-                        "value35",
-                        "value36",
-                        "value37",
-                        "value38",
-                        "value39",
-                        "value40",
-                        "value41",
-                        "value42",
-                        "value43",
-                        "value44",
-                        "value45",
-                        "value46",
-                        "value47",
-                        "value48",
-                        "value49",
-                        "value50",
-                        "value51",
-                        "value52",
-                        "value53",
-                        "value54",
-                        "value55",
-                        "value56",
-                        "value57",
-                        "value58",
-                        "value59",
-                        "value60",
-                        "value61",
-                        "value62",
-                        "value63",
-                        "value64",
-                        "value65",
-                        "value66",
-                        "value67",
-                        "value68",
-                        "value69",
-                        "value70",
-                        "value71",
-                        "value72",
-                        "value73",
-                        "value74",
-                        "value75",
-                        "value76",
-                        "value77",
-                        "value78",
-                        "value79",
-                        "value80",
-                        "value81",
-                        "value82",
-                        "value83",
-                        "value84",
-                        "value85",
-                        "value86",
-                        "value87",
-                        "value88",
-                        "value89",
-                        "value90",
-                        "value91",
-                        "value92",
-                        "value93",
-                        "value94",
-                        "value95",
-                        "value96",
-                        "value97",
-                        "value98",
-                        "value99",
-                        "value100");
+                new TestingRecordsWithSplitIds<>("test-split", recordArr);
         final SourceReader<?, ?> reader =
                 createReaderAndAwaitAvailable(
                         "test-split", records, RateLimiterStrategy.perSecond(1));
         TestingReaderOutput testingReaderOutput = new TestingReaderOutput<>();
         long startTime = System.currentTimeMillis();
-        while (testingReaderOutput.getEmittedRecords().size() < 100) {
+        while (testingReaderOutput.getEmittedRecords().size() < recordArr.length) {
             reader.pollNext(testingReaderOutput);
         }
         // The first few seconds require preheating, there may be a deviation of a few seconds.
         assertThat(System.currentTimeMillis() - startTime)
                 .isGreaterThanOrEqualTo(Duration.ofSeconds(90).toMillis());
+    }
+
+    @Test
+    void testLimitingRatePerCheckpointInSplitReader() throws Exception {
+        String[] recordArr = new String[100];
+        for (int i = 0; i < recordArr.length; i++) {
+            recordArr[i] = "value" + i;
+        }
+        final TestingRecordsWithSplitIds<String> records =
+                new TestingRecordsWithSplitIds<>("test-split", recordArr);
+        int recordsPerCheckpoint = 10;
+        final SourceReader<?, ?> reader =
+                createReaderAndAwaitAvailable(
+                        "test-split",
+                        records,
+                        RateLimiterStrategy.perCheckpoint(recordsPerCheckpoint));
+        TestingReaderOutput testingReaderOutput = new TestingReaderOutput<>();
+        for (int i = 1; i <= recordArr.length / recordsPerCheckpoint; i++) {
+            long startTime = System.currentTimeMillis();
+            while (System.currentTimeMillis() - startTime < Duration.ofSeconds(6).toMillis()) {
+                reader.pollNext(testingReaderOutput);
+            }
+            assertThat(testingReaderOutput.getEmittedRecords().size())
+                    .isLessThanOrEqualTo(1 + recordsPerCheckpoint * i);
+        }
     }
 
     @Test

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -184,7 +184,10 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
                 reader.pollNext(testingReaderOutput);
             }
             assertThat(testingReaderOutput.getEmittedRecords().size())
+                    .isGreaterThanOrEqualTo(1 + recordsPerCheckpoint * (i - 1));
+            assertThat(testingReaderOutput.getEmittedRecords().size())
                     .isLessThanOrEqualTo(1 + recordsPerCheckpoint * i);
+            reader.notifyCheckpointComplete(i);
         }
     }
 
@@ -478,7 +481,9 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
                         rateLimiterStrategy) {
 
                     @Override
-                    public void notifyCheckpointComplete(long checkpointId) {}
+                    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+                        super.notifyCheckpointComplete(checkpointId);
+                    }
 
                     @Override
                     protected void onSplitFinished(

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -169,6 +169,7 @@ class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
         while (testingReaderOutput.getEmittedRecords().size() < recordArr.length) {
             reader.pollNext(testingReaderOutput);
         }
+        // Expected time: 60/2 ("test-split1") = 30 seconds.
         // The first few seconds require preheating, there may be a deviation of a few seconds.
         assertThat(System.currentTimeMillis() - startTime)
                 .isGreaterThan(Duration.ofSeconds(25).toMillis())

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -20,11 +20,14 @@ package org.apache.flink.connector.base.source.reader.mocks;
 
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+
+import javax.annotation.Nullable;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -63,6 +66,21 @@ public class MockSourceReader
                 recordEvaluator,
                 config,
                 context);
+    }
+
+    public MockSourceReader(
+            SingleThreadFetcherManager<int[], MockSourceSplit> splitSplitFetcherManager,
+            Configuration config,
+            SourceReaderContext context,
+            RecordEvaluator<Integer> recordEvaluator,
+            @Nullable RateLimiterStrategy<MockSourceSplit> rateLimiterStrategy) {
+        super(
+                splitSplitFetcherManager,
+                new MockRecordEmitter(context.metricGroup()),
+                recordEvaluator,
+                config,
+                context,
+                rateLimiterStrategy);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.connector.source.util.ratelimit;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -31,7 +32,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * external notifications.
  */
 @Internal
-public class GatedRateLimiter<S> implements RateLimiter<S> {
+public class GatedRateLimiter<Split extends SourceSplit> implements RateLimiter<Split> {
 
     private final int capacityPerCycle;
     private int capacityLeft;

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
@@ -51,14 +51,14 @@ public class GatedRateLimiter<Split extends SourceSplit> implements RateLimiter<
     transient CompletableFuture<Void> gatingFuture = null;
 
     @Override
-    public CompletionStage<Void> acquire(int requestSize) {
+    public CompletionStage<Void> acquire(int numberOfEvents) {
         if (gatingFuture == null) {
             gatingFuture = CompletableFuture.completedFuture(null);
         }
         if (capacityLeft <= 0) {
             gatingFuture = new CompletableFuture<>();
         }
-        return gatingFuture.thenRun(() -> capacityLeft -= requestSize);
+        return gatingFuture.thenRun(() -> capacityLeft -= numberOfEvents);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GatedRateLimiter.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * external notifications.
  */
 @Internal
-public class GatedRateLimiter implements RateLimiter {
+public class GatedRateLimiter<S> implements RateLimiter<S> {
 
     private final int capacityPerCycle;
     private int capacityLeft;
@@ -50,14 +50,14 @@ public class GatedRateLimiter implements RateLimiter {
     transient CompletableFuture<Void> gatingFuture = null;
 
     @Override
-    public CompletionStage<Void> acquire() {
+    public CompletionStage<Void> acquire(int requestSize) {
         if (gatingFuture == null) {
             gatingFuture = CompletableFuture.completedFuture(null);
         }
         if (capacityLeft <= 0) {
             gatingFuture = new CompletableFuture<>();
         }
-        return gatingFuture.thenRun(() -> capacityLeft -= 1);
+        return gatingFuture.thenRun(() -> capacityLeft -= requestSize);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.connector.source.util.ratelimit;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.apache.flink.shaded.guava33.com.google.common.util.concurrent.RateLimiter;
@@ -30,8 +31,8 @@ import java.util.concurrent.Executors;
 
 /** An implementation of {@link RateLimiter} based on Guava's RateLimiter. */
 @Internal
-public class GuavaRateLimiter<S>
-        implements org.apache.flink.api.connector.source.util.ratelimit.RateLimiter<S> {
+public class GuavaRateLimiter<Split extends SourceSplit>
+        implements org.apache.flink.api.connector.source.util.ratelimit.RateLimiter<Split> {
 
     private final Executor limiter =
             Executors.newSingleThreadExecutor(new ExecutorThreadFactory("flink-rate-limiter"));

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
@@ -43,7 +43,7 @@ public class GuavaRateLimiter<Split extends SourceSplit>
     }
 
     @Override
-    public CompletionStage<Void> acquire(int requestSize) {
-        return CompletableFuture.runAsync(() -> rateLimiter.acquire(requestSize), limiter);
+    public CompletionStage<Void> acquire(int numberOfEvents) {
+        return CompletableFuture.runAsync(() -> rateLimiter.acquire(numberOfEvents), limiter);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/GuavaRateLimiter.java
@@ -30,8 +30,8 @@ import java.util.concurrent.Executors;
 
 /** An implementation of {@link RateLimiter} based on Guava's RateLimiter. */
 @Internal
-public class GuavaRateLimiter
-        implements org.apache.flink.api.connector.source.util.ratelimit.RateLimiter {
+public class GuavaRateLimiter<S>
+        implements org.apache.flink.api.connector.source.util.ratelimit.RateLimiter<S> {
 
     private final Executor limiter =
             Executors.newSingleThreadExecutor(new ExecutorThreadFactory("flink-rate-limiter"));
@@ -42,7 +42,7 @@ public class GuavaRateLimiter
     }
 
     @Override
-    public CompletionStage<Void> acquire() {
-        return CompletableFuture.runAsync(rateLimiter::acquire, limiter);
+    public CompletionStage<Void> acquire(int requestSize) {
+        return CompletableFuture.runAsync(() -> rateLimiter.acquire(requestSize), limiter);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletionStage;
 public class NoOpRateLimiter<Split extends SourceSplit> implements RateLimiter<Split> {
 
     @Override
-    public CompletionStage<Void> acquire(int requestSize) {
+    public CompletionStage<Void> acquire(int numberOfEvents) {
         return FutureUtils.completedVoidFuture();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
@@ -25,10 +25,10 @@ import java.util.concurrent.CompletionStage;
 
 /** A convenience implementation of {@link RateLimiter} that does not throttle requests. */
 @Internal
-public class NoOpRateLimiter implements RateLimiter {
+public class NoOpRateLimiter<S> implements RateLimiter<S> {
 
     @Override
-    public CompletionStage<Void> acquire() {
+    public CompletionStage<Void> acquire(int requestSize) {
         return FutureUtils.completedVoidFuture();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/NoOpRateLimiter.java
@@ -19,13 +19,14 @@
 package org.apache.flink.api.connector.source.util.ratelimit;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.concurrent.CompletionStage;
 
 /** A convenience implementation of {@link RateLimiter} that does not throttle requests. */
 @Internal
-public class NoOpRateLimiter<S> implements RateLimiter<S> {
+public class NoOpRateLimiter<Split extends SourceSplit> implements RateLimiter<Split> {
 
     @Override
     public CompletionStage<Void> acquire(int requestSize) {

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimitedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimitedSourceReader.java
@@ -35,7 +35,7 @@ public class RateLimitedSourceReader<E, SplitT extends SourceSplit>
         implements SourceReader<E, SplitT> {
 
     private final SourceReader<E, SplitT> sourceReader;
-    private final RateLimiter rateLimiter;
+    private final RateLimiter<SplitT> rateLimiter;
     private CompletableFuture<Void> availabilityFuture = null;
 
     /**
@@ -44,7 +44,8 @@ public class RateLimitedSourceReader<E, SplitT extends SourceSplit>
      * @param sourceReader The actual source reader.
      * @param rateLimiter The rate limiter.
      */
-    public RateLimitedSourceReader(SourceReader<E, SplitT> sourceReader, RateLimiter rateLimiter) {
+    public RateLimitedSourceReader(
+            SourceReader<E, SplitT> sourceReader, RateLimiter<SplitT> rateLimiter) {
         checkNotNull(sourceReader);
         checkNotNull(rateLimiter);
         this.sourceReader = sourceReader;

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
@@ -19,15 +19,20 @@
 package org.apache.flink.api.connector.source.util.ratelimit;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.connector.source.SourceSplit;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.concurrent.CompletionStage;
 
-/** The interface to rate limit execution of methods. */
+/**
+ * The interface to rate limit execution of methods.
+ *
+ * @param <SplitT> The type of the source splits.
+ */
 @NotThreadSafe
 @Experimental
-public interface RateLimiter<S> {
+public interface RateLimiter<SplitT extends SourceSplit> {
 
     /**
      * Returns a future that is completed once another event would not exceed the rate limit. For
@@ -57,10 +62,8 @@ public interface RateLimiter<S> {
     default void notifyCheckpointComplete(long checkpointId) {}
 
     /**
-     * Notifies this {@code RateLimiter} that the status has changed. This can be used to adjust the
-     * rate limiting behavior based on the new status.
-     *
-     * @param status The new status.
+     * Notifies this {@code RateLimiter} that a new split has been added. the result of before
+     * {@link #acquire(int)} method call should be ensured to be completed when calling this method.
      */
-    default void notifyStatusChange(S status) {}
+    default void notifyAddingSplit(SplitT split) {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
@@ -27,14 +27,25 @@ import java.util.concurrent.CompletionStage;
 /** The interface to rate limit execution of methods. */
 @NotThreadSafe
 @Experimental
-public interface RateLimiter {
+public interface RateLimiter<S> {
 
     /**
      * Returns a future that is completed once another event would not exceed the rate limit. For
      * correct functioning, the next invocation of this method should only happen after the
      * previously returned future has been completed.
      */
-    CompletionStage<Void> acquire();
+    default CompletionStage<Void> acquire() {
+        return acquire(1);
+    }
+
+    /**
+     * Returns a future that is completed once another event would not exceed the rate limit. For
+     * correct functioning, the next invocation of this method should only happen after the
+     * previously returned future has been completed.
+     *
+     * @param requestSize The size of requests.
+     */
+    CompletionStage<Void> acquire(int requestSize);
 
     /**
      * Notifies this {@code RateLimiter} that the checkpoint with the given {@code checkpointId}
@@ -44,4 +55,12 @@ public interface RateLimiter {
      * @param checkpointId The ID of the checkpoint that has been completed.
      */
     default void notifyCheckpointComplete(long checkpointId) {}
+
+    /**
+     * Notifies this {@code RateLimiter} that the status has changed. This can be used to adjust the
+     * rate limiting behavior based on the new status.
+     *
+     * @param status The new status.
+     */
+    default void notifyStatusChange(S status) {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiter.java
@@ -44,13 +44,13 @@ public interface RateLimiter<SplitT extends SourceSplit> {
     }
 
     /**
-     * Returns a future that is completed once another event would not exceed the rate limit. For
+     * Returns a future that is completed once other events would not exceed the rate limit. For
      * correct functioning, the next invocation of this method should only happen after the
      * previously returned future has been completed.
      *
-     * @param requestSize The size of requests.
+     * @param numberOfEvents The number of events.
      */
-    CompletionStage<Void> acquire(int requestSize);
+    CompletionStage<Void> acquire(int numberOfEvents);
 
     /**
      * Notifies this {@code RateLimiter} that the checkpoint with the given {@code checkpointId}
@@ -62,8 +62,11 @@ public interface RateLimiter<SplitT extends SourceSplit> {
     default void notifyCheckpointComplete(long checkpointId) {}
 
     /**
-     * Notifies this {@code RateLimiter} that a new split has been added. the result of before
-     * {@link #acquire(int)} method call should be ensured to be completed when calling this method.
+     * Notifies this {@code RateLimiter} that a new split has been added. For correct functioning,
+     * this method should only be invoked after the returned future of previous {@link
+     * #acquire(int)} method invocation has been completed.
+     *
+     * @param split The split that has been added.
      */
     default void notifyAddingSplit(SplitT split) {}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
@@ -27,14 +27,14 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  * A factory for {@link RateLimiter RateLimiters} which apply rate-limiting to a source sub-task.
  */
 @Experimental
-public interface RateLimiterStrategy extends Serializable {
+public interface RateLimiterStrategy<S> extends Serializable {
 
     /**
      * Creates a {@link RateLimiter} that lets records through with rate proportional to the
      * parallelism. This method will be called once per source subtask. The cumulative rate over all
      * rate limiters for a source must not exceed the rate limit configured for the strategy.
      */
-    RateLimiter createRateLimiter(int parallelism);
+    RateLimiter<S> createRateLimiter(int parallelism);
 
     /**
      * Creates a {@code RateLimiterStrategy} that is limiting the number of records per second.
@@ -44,7 +44,7 @@ public interface RateLimiterStrategy extends Serializable {
      *     among the parallel instances.
      */
     static RateLimiterStrategy perSecond(double recordsPerSecond) {
-        return parallelism -> new GuavaRateLimiter(recordsPerSecond / parallelism);
+        return parallelism -> new GuavaRateLimiter<>(recordsPerSecond / parallelism);
     }
 
     /**
@@ -62,7 +62,7 @@ public interface RateLimiterStrategy extends Serializable {
                     "recordsPerCheckpoint has to be greater or equal to parallelism. "
                             + "Either decrease the parallelism or increase the number of "
                             + "recordsPerCheckpoint.");
-            return new GatedRateLimiter(recordsPerSubtask);
+            return new GatedRateLimiter<>(recordsPerSubtask);
         };
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
@@ -30,9 +30,9 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public interface RateLimiterStrategy<S> extends Serializable {
 
     /**
-     * Creates a {@link RateLimiter} that lets records through with rate proportional to the
-     * parallelism. This method will be called once per source subtask. The cumulative rate over all
-     * rate limiters for a source must not exceed the rate limit configured for the strategy.
+     * Creates a {@link RateLimiter} that limits the rate of records going through. When there is
+     * parallelism, the limiting rate is evenly reduced per subtask, such that all the sub-tasks
+     * limiting rates equals the cumulative limiting rate.
      */
     RateLimiter<S> createRateLimiter(int parallelism);
 

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimiterStrategy.java
@@ -18,6 +18,7 @@
 package org.apache.flink.api.connector.source.util.ratelimit;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.connector.source.SourceSplit;
 
 import java.io.Serializable;
 
@@ -25,16 +26,18 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A factory for {@link RateLimiter RateLimiters} which apply rate-limiting to a source sub-task.
+ *
+ * @param <SplitT> The type of the source splits.
  */
 @Experimental
-public interface RateLimiterStrategy<S> extends Serializable {
+public interface RateLimiterStrategy<SplitT extends SourceSplit> extends Serializable {
 
     /**
      * Creates a {@link RateLimiter} that limits the rate of records going through. When there is
      * parallelism, the limiting rate is evenly reduced per subtask, such that all the sub-tasks
      * limiting rates equals the cumulative limiting rate.
      */
-    RateLimiter<S> createRateLimiter(int parallelism);
+    RateLimiter<SplitT> createRateLimiter(int parallelism);
 
     /**
      * Creates a {@code RateLimiterStrategy} that is limiting the number of records per second.

--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.connector.source.lib.util;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiter;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
 import org.apache.flink.connector.datagen.source.DataGeneratorSource;
@@ -87,7 +88,8 @@ public class RateLimitedSourceReaderITCase extends TestLogger {
                 .collect(Collectors.toList());
     }
 
-    private static final class MockRateLimiter implements RateLimiter {
+    private static final class MockRateLimiter
+            implements RateLimiter<NumberSequenceSource.NumberSequenceSplit> {
 
         int callCount;
 
@@ -102,13 +104,15 @@ public class RateLimitedSourceReaderITCase extends TestLogger {
         }
     }
 
-    private static class MockRateLimiterStrategy implements RateLimiterStrategy {
+    private static class MockRateLimiterStrategy
+            implements RateLimiterStrategy<NumberSequenceSource.NumberSequenceSplit> {
 
         private static final List<MockRateLimiter> rateLimiters =
                 Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public RateLimiter createRateLimiter(int parallelism) {
+        public RateLimiter<NumberSequenceSource.NumberSequenceSplit> createRateLimiter(
+                int parallelism) {
             MockRateLimiter mockRateLimiter = new MockRateLimiter();
             rateLimiters.add(mockRateLimiter);
             return mockRateLimiter;

--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
@@ -94,7 +94,7 @@ public class RateLimitedSourceReaderITCase extends TestLogger {
         int callCount;
 
         @Override
-        public CompletableFuture<Void> acquire(int requestSize) {
+        public CompletableFuture<Void> acquire(int numberOfEvents) {
             callCount++;
             return CompletableFuture.completedFuture(null);
         }

--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
@@ -92,7 +92,7 @@ public class RateLimitedSourceReaderITCase extends TestLogger {
         int callCount;
 
         @Override
-        public CompletableFuture<Void> acquire() {
+        public CompletableFuture<Void> acquire(int requestSize) {
             callCount++;
             return CompletableFuture.completedFuture(null);
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.connector.source.util.ratelimit.GatedRateLimiter;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiter;
 import org.apache.flink.api.connector.source.util.ratelimit.RateLimiterStrategy;
@@ -365,7 +366,7 @@ public class SinkV2ITCase extends AbstractTestBase {
      * for another two checkpoints and 5) exiting.
      */
     private Source<Integer, ?, ?> createStreamingSource() {
-        RateLimiterStrategy<Void> rateLimiterStrategy =
+        RateLimiterStrategy<NumberSequenceSource.NumberSequenceSplit> rateLimiterStrategy =
                 parallelism -> new BurstingRateLimiter(SOURCE_DATA.size() / 4, 2);
         return new DataGeneratorSource<>(
                 l -> SOURCE_DATA.get(l.intValue() % SOURCE_DATA.size()),
@@ -374,8 +375,9 @@ public class SinkV2ITCase extends AbstractTestBase {
                 IntegerTypeInfo.INT_TYPE_INFO);
     }
 
-    private static class BurstingRateLimiter implements RateLimiter<Void> {
-        private final RateLimiter<Void> rateLimiter;
+    private static class BurstingRateLimiter
+            implements RateLimiter<NumberSequenceSource.NumberSequenceSplit> {
+        private final RateLimiter<NumberSequenceSource.NumberSequenceSplit> rateLimiter;
         private final int numCheckpointCooldown;
         private int cooldown;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -387,8 +387,8 @@ public class SinkV2ITCase extends AbstractTestBase {
         }
 
         @Override
-        public CompletionStage<Void> acquire(int requestSize) {
-            CompletionStage<Void> stage = rateLimiter.acquire(requestSize);
+        public CompletionStage<Void> acquire(int numberOfEvents) {
+            CompletionStage<Void> stage = rateLimiter.acquire(numberOfEvents);
             cooldown = numCheckpointCooldown;
             return stage;
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkV2ITCase.java
@@ -365,7 +365,7 @@ public class SinkV2ITCase extends AbstractTestBase {
      * for another two checkpoints and 5) exiting.
      */
     private Source<Integer, ?, ?> createStreamingSource() {
-        RateLimiterStrategy rateLimiterStrategy =
+        RateLimiterStrategy<Void> rateLimiterStrategy =
                 parallelism -> new BurstingRateLimiter(SOURCE_DATA.size() / 4, 2);
         return new DataGeneratorSource<>(
                 l -> SOURCE_DATA.get(l.intValue() % SOURCE_DATA.size()),
@@ -374,19 +374,19 @@ public class SinkV2ITCase extends AbstractTestBase {
                 IntegerTypeInfo.INT_TYPE_INFO);
     }
 
-    private static class BurstingRateLimiter implements RateLimiter {
-        private final RateLimiter rateLimiter;
+    private static class BurstingRateLimiter implements RateLimiter<Void> {
+        private final RateLimiter<Void> rateLimiter;
         private final int numCheckpointCooldown;
         private int cooldown;
 
         public BurstingRateLimiter(int recordPerCycle, int numCheckpointCooldown) {
-            rateLimiter = new GatedRateLimiter(recordPerCycle);
+            rateLimiter = new GatedRateLimiter<>(recordPerCycle);
             this.numCheckpointCooldown = numCheckpointCooldown;
         }
 
         @Override
-        public CompletionStage<Void> acquire() {
-            CompletionStage<Void> stage = rateLimiter.acquire();
+        public CompletionStage<Void> acquire(int requestSize) {
+            CompletionStage<Void> stage = rateLimiter.acquire(requestSize);
             cooldown = numCheckpointCooldown;
             return stage;
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
